### PR TITLE
[core] Update useId dependency

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [borabaloglu]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,12 +52,14 @@
     "lint": "eslint . --max-warnings 0"
   },
   "peerDependencies": {
+    "@base-ui-components/react": "1.0.0-beta.1",
     "react": "^18 || ^19 || ^19.0.0-rc",
-    "react-dom": "^18 || ^19 || ^19.0.0-rc",
-    "@base-ui-components/react": "1.0.0-beta.1"
+    "react-dom": "^18 || ^19 || ^19.0.0-rc"
   },
   "devDependencies": {
     "@types/react": "^18.2.46"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@base-ui-components/utils": "^0.1.0"
+  }
 }

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -7,7 +7,7 @@
 
 import * as React from "react"
 import { Dialog as BaseDialog } from "@base-ui-components/react"
-import { useId } from "@base-ui-components/react/utils"
+import { useId } from "@base-ui-components/utils/useId"
 
 import { commandScore } from "./command-score"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@base-ui-components/react':
         specifier: 1.0.0-beta.1
         version: 1.0.0-beta.1(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@base-ui-components/utils':
+        specifier: ^0.1.0
+        version: 0.1.0(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18 || ^19 || ^19.0.0-rc
         version: 18.3.1
@@ -180,6 +183,16 @@ packages:
   '@base-ui-components/react@1.0.0-beta.1':
     resolution: {integrity: sha512-7zmGiz4/+HKnv99lWftItoSMqnj2PdSvt2krh0/GP+Rj0xK0NMnFI/gIVvP7CB2G+k0JPUrRWXjXa3y08oiakg==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui-components/utils@0.1.0':
+    resolution: {integrity: sha512-9+uaWyF1o/PgXqHLJnC81IIG0HlV3o9eFCQ5hWZDMx5NHrFk0rrwqEFGQOB8lti/rnbxNPi+kYYw1D4e8xSn/Q==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -2689,6 +2702,17 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       reselect: 5.1.1
       tabbable: 6.2.0
+      use-sync-external-store: 1.5.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+
+  '@base-ui-components/utils@0.1.0(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@floating-ui/utils': 0.2.10
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
       use-sync-external-store: 1.5.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.18


### PR DESCRIPTION
Build still works, there was no tests (happy to write some if that helps)

```
 ~/code/cmdk-base  main !3  pnpm build --filter=cmdk-base                                                                                     ✔  1m 14s  osrs    20.16.0 

> cmdk-base@ build /Users/knd/code/cmdk-base
> turbo build "--filter=cmdk-base"

╭──────────────────────────────────────────────────────────────────────────╮
│                                                                          │
│                     Update available v2.3.4 ≫ v2.5.5                     │
│    Changelog: https://github.com/vercel/turborepo/releases/tag/v2.5.5    │
│             Run "npx @turbo/codemod@latest update" to update             │
│                                                                          │
│          Follow @turborepo for updates: https://x.com/turborepo          │
╰──────────────────────────────────────────────────────────────────────────╯
turbo 2.3.4

• Packages in scope: cmdk-base
• Running build in 1 packages
• Remote caching disabled
┌ cmdk-base#build > cache miss, executing 4703f30be3f6c6c5
│
│
│ > cmdk-base@0.0.6 build /Users/knd/code/cmdk-base/packages/core
│ > pnpm type-check && bunchee && pnpm copy-readme
│
│
│ > cmdk-base@0.0.6 type-check /Users/knd/code/cmdk-base/packages/core
│ > tsc --noEmit
│
│ Exports  File              Size
│ .        dist/index.mjs    39.9 kB
│          dist/index.js     41.2 kB
│          dist/index.d.ts   15.2 kB
│          dist/index.d.mts  15.2 kB
│
│ > cmdk-base@0.0.6 copy-readme /Users/knd/code/cmdk-base/packages/core
│ > cp ../../README.md ./README.md
└────>

 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total
  Time:    3.996s

```